### PR TITLE
Add option to disable question marking

### DIFF
--- a/index.html
+++ b/index.html
@@ -74,10 +74,16 @@
                         </label>
                     </div>
                     <div>
-                    <label class="form-check-label">
-                        <input id="countdownMode" type="checkbox">
-                        Countdown mode <abbr title="Instead of showing the total number of mines around a tile, show the remaining (based on placed flags)">(?)</abbr>
-                    </label>
+                        <label class="form-check-label">
+                            <input id="countdownMode" type="checkbox">
+                            Countdown mode <abbr title="Instead of showing the total number of mines around a tile, show the remaining (based on placed flags)">(?)</abbr>
+                        </label>
+                    </div>
+                    <div>
+                        <label class="form-check-label">
+                            <input id="questionMarkingDisabled" type="checkbox">
+                            Disable question marking
+                        </label>
                     </div>
                     <div>
                         <button onClick="hint()" class="btn btn-light btn-sm mt-2">Give me a hint</button>

--- a/index.js
+++ b/index.js
@@ -30,6 +30,7 @@ class Game {
     this.allowOutside = false;
     this.safeMode = false;
     this.countdownMode = false;
+    this.questionMarkingDisabled = false;
 
     this.lastDuration = 0;
     this.recalc();
@@ -331,7 +332,9 @@ class Game {
       this.unsure[y][x] = false;
     } else if (this.flags[y][x]) {
       this.flags[y][x] = false;
-      this.unsure[y][x] = true;
+      if (!this.questionMarkingDisabled) {
+        this.unsure[y][x] = true;
+      }
     } else {
       this.flags[y][x] = true;
     }
@@ -861,7 +864,7 @@ function undo() {
   game.undo();
 }
 
-const SETTINGS = ['debug', 'allowOutside', 'safeMode', 'countdownMode'];
+const SETTINGS = ['debug', 'allowOutside', 'safeMode', 'countdownMode', 'questionMarkingDisabled'];
 
 function updateSettings() {
   for (const name of SETTINGS) {


### PR DESCRIPTION
This pull request makes question marking an optional feature, in case players only want to mark mines as flagged.

I also indented one of the other options in index.html so that it matches the other elements. I can revert that change if it's not necessary.

If there are any other issues with this pull request please let me know.